### PR TITLE
Use custom compiled SQLite binary

### DIFF
--- a/codelists/tests/test_db_utils.py
+++ b/codelists/tests/test_db_utils.py
@@ -1,0 +1,14 @@
+from django.test import TestCase
+
+from opencodelists import db_utils
+
+
+class DBUtilsTest(TestCase):
+    def test_query_with_many_params(self):
+        values = list(range(5000))
+        placeholders = ["%s"] * len(values)
+        sql = "SELECT 'found' WHERE %s IN ({})".format(", ".join(placeholders))
+        last_value = values[-1]
+        params = [last_value] + values
+        result = db_utils.query(sql, params)
+        self.assertEqual(result, [("found",)])

--- a/requirements.in
+++ b/requirements.in
@@ -15,3 +15,4 @@ black
 flake8
 isort
 litecli
+pip-tools

--- a/requirements.in
+++ b/requirements.in
@@ -4,7 +4,9 @@ django-cors-headers
 django-markdown-filter
 gunicorn
 networkx
-pysqlite3-binary
+# pysqlite3-binary
+# Temporarily replace pysqlite3-binary with a custom compiled version which has had the parameter limit bumped
+https://github.com/evansd/pysqlite3/releases/download/0.4.2%2Bmaxargsbump/pysqlite3-0.4.2+maxargsbump-cp36-cp36m-manylinux1_x86_64.whl
 whitenoise
 
 # test

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ black==19.10b0            # via -r requirements.in
 bleach==3.1.4             # via django-markdown-filter
 cffi==1.14.0              # via bcrypt, cryptography, pynacl
 cli-helpers[styles]==1.2.1  # via litecli
-click==7.1.2              # via black, litecli
+click==7.1.2              # via black, litecli, pip-tools
 configobj==5.0.6          # via cli-helpers, litecli
 cryptography==2.9.2       # via paramiko
 decorator==4.4.2          # via networkx
@@ -31,6 +31,7 @@ mccabe==0.6.1             # via flake8
 networkx==2.4             # via -r requirements.in
 paramiko==2.7.1           # via fabric3
 pathspec==0.8.0           # via black
+pip-tools==5.1.2          # via -r requirements.in
 prompt-toolkit==3.0.5     # via litecli
 pycodestyle==2.5.0        # via flake8
 pycparser==2.20           # via cffi
@@ -40,7 +41,7 @@ pynacl==1.3.0             # via paramiko
 pysqlite3-binary==0.4.2   # via -r requirements.in
 pytz==2020.1              # via django
 regex==2020.4.4           # via black
-six==1.14.0               # via bcrypt, bleach, configobj, cryptography, fabric3, pynacl
+six==1.14.0               # via bcrypt, bleach, configobj, cryptography, fabric3, pip-tools, pynacl
 sortedcontainers==2.1.0   # via hypothesis
 sqlparse==0.3.1           # via django, litecli
 tabulate[widechars]==0.8.7  # via cli-helpers
@@ -52,4 +53,5 @@ webencodings==0.5.1       # via bleach
 whitenoise==5.0.1         # via -r requirements.in
 
 # The following packages are considered to be unsafe in a requirements file:
+# pip
 # setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ pycparser==2.20           # via cffi
 pyflakes==2.1.1           # via flake8
 pygments==2.6.1           # via cli-helpers, litecli
 pynacl==1.3.0             # via paramiko
-pysqlite3-binary==0.4.2   # via -r requirements.in
+https://github.com/evansd/pysqlite3/releases/download/0.4.2%2Bmaxargsbump/pysqlite3-0.4.2+maxargsbump-cp36-cp36m-manylinux1_x86_64.whl  # via -r requirements.in
 pytz==2020.1              # via django
 regex==2020.4.4           # via black
 six==1.14.0               # via bcrypt, bleach, configobj, cryptography, fabric3, pip-tools, pynacl


### PR DESCRIPTION
Due to its use in tiny embedded systems, SQLite has quite a low default
parameter limit (999). Most OS distributions bump this signficantly
(e.g. Ubuntu to 250,000 and OS X to 500,000) but the pysqlite3-binary
package leaves it at the default. Until we get a change merged upstream
we use a custom-compiled package.